### PR TITLE
3 プレビューの生成方法を修正する

### DIFF
--- a/app/Jobs/ProcessMangaUpload.php
+++ b/app/Jobs/ProcessMangaUpload.php
@@ -32,7 +32,7 @@ class ProcessMangaUpload implements ShouldQueue
 
         try {
             foreach ($mangaPages as $page) {
-                $imageService->generateThumbnail($page->path ,$page->lite_path);
+                $imageService->generateLiteImage($page->path ,$page->lite_path);
             }
         } catch (\Throwable $e) {
             // 保存済みのMangaがある場合は削除

--- a/app/Jobs/TusdHooks/PostFinish/ProcessImage.php
+++ b/app/Jobs/TusdHooks/PostFinish/ProcessImage.php
@@ -47,9 +47,9 @@ class ProcessImage implements ShouldQueue
                 $extension = pathinfo($filePath, PATHINFO_EXTENSION);
                 // imageからprev画像を生成
                 $imagePrevPath = $this->imageService->generateImagePrev(MediaFolderTypes::IMAGES, $uniqueBaseName, $filePath);
-                // imageから一時置き換え用の低画質画像を生成
+                // imageから一時置き換え用の低画質画像を生成。prevと全く同じ画像なのは、現時点では仕様。
                 $imageLitePath = "extras/images/{$uniqueBaseName}/lite.webp";
-                $this->imageService->generateThumbnail($filePath, $imageLitePath);
+                $this->imageService->generateLiteImage($filePath, $imageLitePath);
                 // 寸法を取得
                 [$width, $height] = $this->imageService->getDimensions($filePath);
 

--- a/app/Jobs/TusdHooks/PostFinish/ProcessImage.php
+++ b/app/Jobs/TusdHooks/PostFinish/ProcessImage.php
@@ -47,15 +47,12 @@ class ProcessImage implements ShouldQueue
                 $extension = pathinfo($filePath, PATHINFO_EXTENSION);
                 // imageからprev画像を生成
                 $imagePrevPath = $this->imageService->generateImagePrev(MediaFolderTypes::IMAGES, $uniqueBaseName, $filePath);
-                // imageから一時置き換え用の低画質画像を生成。prevと全く同じ画像なのは、現時点では仕様。
-                $imageLitePath = "extras/images/{$uniqueBaseName}/lite.webp";
-                $this->imageService->generateLiteImage($filePath, $imageLitePath);
+
                 // 寸法を取得
                 [$width, $height] = $this->imageService->getDimensions($filePath);
 
                 // imagesへ保存
                 $image = new Image();
-                $image->lite_path = $imageLitePath;
                 $image->extension = $extension;
                 $image->width = $width;
                 $image->height = $height;

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
 
 /**
  * @property int $id
- * @property string $lite_path
  * @property string $extension
  * @property string $dimensions
  * @property \DateTime|null $created_at

--- a/database/migrations/2024_11_10_040533_create_images_table.php
+++ b/database/migrations/2024_11_10_040533_create_images_table.php
@@ -13,7 +13,6 @@ return new class extends Migration
     {
         Schema::create('images', function (Blueprint $table) {
             $table->id();
-            $table->string('lite_path');
             $table->string('extension', 10);
             $table->integer("width");
             $table->integer("height");

--- a/resources/js/Pages/Media/Index/Partials/MediaPrev.vue
+++ b/resources/js/Pages/Media/Index/Partials/MediaPrev.vue
@@ -35,7 +35,7 @@ const togglePlay = () => {
         <img v-if="mediaFile.preview_image_path"
              :src="getPrivateStoragePath(mediaFile.preview_image_path)"
              :alt="mediaFile.title"
-             class="w-full h-auto"
+             class="w-full h-full object-cover object-top"
         />
         <div v-else class="w-full h-full bg-gradient-to-r from-slate-900 to-slate-700"/>
         <button v-if="mediaFile.mediable_type === 'App\\Models\\Audio'"

--- a/resources/js/Pages/Media/Index/Partials/MediaPrev.vue
+++ b/resources/js/Pages/Media/Index/Partials/MediaPrev.vue
@@ -51,7 +51,7 @@ const togglePlay = () => {
                 @click="() => {toggleOpenMediaSpace(); setMedia(mediaFile);}" class="absolute inset-0 flex items-center justify-center group">
             <!-- Videoのカバー -->
             <span  class="flex group-hover:bg-black h-full w-full items-center justify-center overflow-hidden">
-                <img :src="getPrivateStoragePath(mediaFile.mediable.preview_video_path)" alt="Videoのホバー時カバー" class="hidden group-hover:block my-auto mx-auto">
+                <img :src="getPrivateStoragePath(mediaFile.mediable.preview_video_path)" alt="Videoのホバー時カバー" class="hidden group-hover:block my-auto mx-auto w-full h-full object-scale-down" />
                 <i-pepicons-pop-clapperboard class="w-24 h-24 absolute top-0 right-0 box-content bg-blue-500 p-4 text-white drop-shadow-xl" />
             </span>
         </button>

--- a/resources/js/stores/media.js
+++ b/resources/js/stores/media.js
@@ -59,7 +59,7 @@ export const useMediaStore = defineStore("media2", () => {
                 break
             case "App\\Models\\Image":
                 isPlaying.value = false;
-                srcLite.value = getPrivateStoragePath(media.mediable.lite_path);
+                srcLite.value = getPrivateStoragePath(media.preview_image_path);
                 break
             default:
                 console.warn("対応していないメディアタイプです");


### PR DESCRIPTION
## 変更点

1. いままでプレビュー画像は1:1にトリミングしていたが、元画像の比率のまま画質縮小&webp化するだけに留めるよう変更
変更理由は、こちらのほうが汎用性が高いので。
1. imagesからlite_pathを削除  
1の仕様変更から、imagesのlite_pathとmedia_filesのpreview_image_pathが全く同じものになったため。

ただ、manga_pagesの1ページ目のlite_pathとmedia_filesのpreview_image_pathが被っているのは仕様という方針。これは、1ページ目のlite_pathだけなくすとか、mangaだけpreview_image_pathを無くすのはなんか気持ち悪いので。  
同じ画像が2枚できるのも仕様だが、preview_image_pathのパスをmanga_pagesの1ページ目のものと同じものにしてしまい画像を1枚にするのもありだとは思う。ただ、一旦これで実装する。